### PR TITLE
Show API quota in the pull comments UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Show the available quota in the pull comments sidebar. (mddburgess/winston#80)
+
+### Changed
+
+- Refresh the available quota in the UI during pull comment requests. (mddburgess/winston#80)
+- Highlight the available quota in yellow or red as it approaches zero. (mddburgess/winston#80)
+
 ## [1.5.0] — 2025-08-20
 
 ### Added

--- a/api/src/schemas/fetch/FetchLimitsResponse.yaml
+++ b/api/src/schemas/fetch/FetchLimitsResponse.yaml
@@ -2,11 +2,14 @@ $schema: https://json-schema.org/draft/2020-12/schema
 title: Fetch Limits Response
 type: object
 required:
-  - remainingQuota
+  - daily_quota
+  - available_quota
 properties:
-  remainingQuota:
-    description: The remaining daily quota available to use on fetch requests.
+  daily_quota:
+    description: The total API quota that can be used per day on fetch requests.
     type: integer
     format: int32
-    minimum: 0
-    maximum: 10000
+  available_quota:
+    description: The remaining available API quota that can be used today on fetch requests.
+    type: integer
+    format: int32

--- a/backend/src/main/java/ca/metricalsky/winston/service/fetch/FetchService.java
+++ b/backend/src/main/java/ca/metricalsky/winston/service/fetch/FetchService.java
@@ -7,6 +7,7 @@ import ca.metricalsky.winston.mapper.entity.FetchRequestMapper;
 import ca.metricalsky.winston.repository.fetch.FetchRequestRepository;
 import ca.metricalsky.winston.repository.fetch.YouTubeRequestRepository;
 import ca.metricalsky.winston.service.fetch.operation.FetchOperationHandlerFactory;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
@@ -25,6 +26,7 @@ public class FetchService {
     private final FetchRequestService fetchRequestService;
     private final YouTubeRequestRepository youTubeRequestRepository;
 
+    @Getter
     @Value("${youtube.quota.daily}")
     private int dailyQuota;
 
@@ -53,7 +55,7 @@ public class FetchService {
         }
     }
 
-    public int getRemainingQuota() {
+    public int getAvailableQuota() {
         var startOfToday = LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC);
         return dailyQuota - youTubeRequestRepository.countAllByRequestedAtAfter(startOfToday);
     }

--- a/backend/src/main/java/ca/metricalsky/winston/web/fetch/FetchController.java
+++ b/backend/src/main/java/ca/metricalsky/winston/web/fetch/FetchController.java
@@ -45,9 +45,9 @@ public class FetchController implements FetchApi {
 
     @Override
     public ResponseEntity<FetchLimitsResponse> getFetchLimits() {
-        var remainingQuota = fetchService.getRemainingQuota();
         var response = new FetchLimitsResponse()
-                .remainingQuota(remainingQuota);
+                .dailyQuota(fetchService.getDailyQuota())
+                .availableQuota(fetchService.getAvailableQuota());
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/test/java/ca/metricalsky/winston/service/fetch/FetchServiceTest.java
+++ b/backend/src/test/java/ca/metricalsky/winston/service/fetch/FetchServiceTest.java
@@ -126,15 +126,15 @@ class FetchServiceTest {
     }
 
     @Test
-    void getRemainingQuota() {
+    void getAvailableQuota() {
         ReflectionTestUtils.setField(fetchService, "dailyQuota", 10000);
 
         when(youTubeRequestRepository.countAllByRequestedAtAfter(any(OffsetDateTime.class)))
                 .thenReturn(1);
 
-        var remainingQuota = fetchService.getRemainingQuota();
+        var availableQuota = fetchService.getAvailableQuota();
 
-        assertThat(remainingQuota)
+        assertThat(availableQuota)
                 .isEqualTo(9999);
     }
 

--- a/frontend/src/Header.tsx
+++ b/frontend/src/Header.tsx
@@ -1,7 +1,7 @@
 import { Dropdown, Nav, NavDropdown } from "react-bootstrap";
 import { EyeFill, List } from "react-bootstrap-icons";
 import { Link } from "react-router";
-import { RemainingQuota } from "./RemainingQuota";
+import { AvailableQuota } from "#/components/limits/AvailableQuota";
 import { routes } from "./utils/links";
 
 export const Header = () => (
@@ -29,12 +29,7 @@ export const Header = () => (
                 </NavDropdown.Item>
                 <NavDropdown.Divider />
                 <Dropdown.Item disabled={true}>
-                    <div className={"small text-body-tertiary"}>
-                        Remaining quota
-                    </div>
-                    <div className={"text-body-tertiary fw-bold"}>
-                        <RemainingQuota />
-                    </div>
+                    <AvailableQuota />
                 </Dropdown.Item>
             </NavDropdown>
         </Nav>

--- a/frontend/src/RemainingQuota.tsx
+++ b/frontend/src/RemainingQuota.tsx
@@ -1,7 +1,0 @@
-import { Spinner } from "react-bootstrap";
-import { useGetFetchLimitsQuery } from "#/api";
-
-export const RemainingQuota = () => {
-    const { data } = useGetFetchLimitsQuery();
-    return data ? <>{data.remainingQuota}</> : <Spinner size={"sm"} />;
-};

--- a/frontend/src/components/limits/AvailableQuota.tsx
+++ b/frontend/src/components/limits/AvailableQuota.tsx
@@ -1,0 +1,32 @@
+import { Col, Row, Spinner } from "react-bootstrap";
+import { useGetFetchLimitsQuery } from "#/api";
+
+const WARNING_PERCENT = 0.2;
+const DANGER_PERCENT = 0.05;
+
+const AvailableQuota = () => {
+    const { data } = useGetFetchLimitsQuery();
+
+    const availablePercent = data
+        ? data.available_quota / data.daily_quota
+        : 100;
+    const textClass =
+        availablePercent <= DANGER_PERCENT
+            ? "text-danger"
+            : availablePercent <= WARNING_PERCENT
+              ? "text-warning"
+              : "text-body-tertiary";
+
+    return (
+        <Row className={textClass}>
+            <Col xs={12} className={"small"}>
+                Quota available
+            </Col>
+            <Col className={`fw-bold ${textClass}`}>
+                {data ? data.available_quota : <Spinner size={"sm"} />}
+            </Col>
+        </Row>
+    );
+};
+
+export { AvailableQuota };

--- a/frontend/src/routes/channels/id/BatchPullCommentsAction.tsx
+++ b/frontend/src/routes/channels/id/BatchPullCommentsAction.tsx
@@ -3,6 +3,7 @@ import { EventSourceProvider } from "react-sse-hooks";
 import { usePullMutation } from "#/api";
 import { NotificationsSource } from "#/components/NotificationsSource";
 import { useAppDispatch } from "#/store/hooks";
+import { invalidateFetchLimits } from "#/store/slices/api";
 import {
     batchPullCommentsData,
     batchPullCommentsStatus,
@@ -45,6 +46,7 @@ const BatchPullCommentsAction = ({ channel, pullComments }: Props) => {
                 replies: event.replies,
             }),
         );
+        dispatch(invalidateFetchLimits());
     };
 
     const handleStatusEvent = (event: FetchStatusEvent) => {
@@ -62,6 +64,7 @@ const BatchPullCommentsAction = ({ channel, pullComments }: Props) => {
                     }),
                 );
             }
+            dispatch(invalidateFetchLimits());
         }
     };
 

--- a/frontend/src/routes/channels/id/BatchPullCommentsSidebar.tsx
+++ b/frontend/src/routes/channels/id/BatchPullCommentsSidebar.tsx
@@ -9,6 +9,7 @@ import {
     ProgressBar,
     Row,
 } from "react-bootstrap";
+import { AvailableQuota } from "#/components/limits/AvailableQuota";
 import { BatchPullCommentsAction } from "#/routes/channels/id/BatchPullCommentsAction";
 import { useAppDispatch, useAppSelector } from "#/store/hooks";
 import { invalidateVideos } from "#/store/slices/backend";
@@ -69,8 +70,15 @@ const BatchPullCommentsSidebar = ({ channel }: ChannelProps) => {
                     <PullCommentsList pullComments={pullComments} />
                 </Container>
             </Offcanvas.Body>
-            <Offcanvas.Body className={"bg-secondary-subtle height-fit"}>
-                <Button onClick={handleClose}>Close</Button>
+            <Offcanvas.Body className={"bg-body-tertiary height-fit"}>
+                <Row className={"flex-center"}>
+                    <Col>
+                        <AvailableQuota />
+                    </Col>
+                    <Col xs={"auto"}>
+                        <Button onClick={handleClose}>Close</Button>
+                    </Col>
+                </Row>
             </Offcanvas.Body>
         </Offcanvas>
     );


### PR DESCRIPTION
* Show the available quota in the pull comments sidebar.
* Refresh the available quota in the UI during pull comment requests.
* Highlight the available quota in yellow or red as it approaches zero.

Fixes #80.